### PR TITLE
Add darwin/arm64 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,13 @@ builds:
       - darwin
       - linux
       - windows
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
 
 archives:
   -

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ get_binaries() {
   case "$PLATFORM" in
     darwin/386) BINARIES="lega-commander" ;;
     darwin/amd64) BINARIES="lega-commander" ;;
+    darwin/arm64) BINARIES="lega-commander" ;;
     linux/386) BINARIES="lega-commander" ;;
     linux/amd64) BINARIES="lega-commander" ;;
     windows/386) BINARIES="lega-commander" ;;


### PR DESCRIPTION
This PR is to create the necessary binaries for darwin/arm64 (apple silicon) architectures.