### PR TITLE
Allowing empty listing/non exisiting inbox for first time upload users

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/buger/jsonparser"
 	"github.com/elixir-oslo/lega-commander/conf"
@@ -58,8 +59,20 @@ func (rm defaultFileManager) ListFiles(inbox bool) (*[]File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, errors.New(response.Status)
+	if response.StatusCode == 403 {
+    		body, err := ioutil.ReadAll(response.Body)
+    		if err != nil {
+    			return nil, errors.New("Failed to read the server's response")
+    		}
+    		// Check if the response body contains the specific error message indicating
+    		// that the folder is empty or doesn't exist yet.
+    		if strings.Contains(string(body), `"tsdFiles" is null`) {
+    			return nil, errors.New("The user folder is empty or does not exist yet")
+    		}
+    		// If it's not an empty folder, it's a genuine authentication error.
+    		return nil, errors.New("Authentication error")
+    	} else if response.StatusCode != 200 {
+    	return nil, errors.New(response.Status)
 	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/files/files.go
+++ b/files/files.go
@@ -30,6 +30,16 @@ type defaultFileManager struct {
 	client requests.Client
 }
 
+// Represents an error message to handle a missing or empty folder
+type FolderNotFoundError struct {
+    Msg string
+}
+
+// Returns the error message in FolderNotFoundError.
+func (e *FolderNotFoundError) Error() string {
+    return e.Msg
+}
+
 // NewFileManager constructs FileManager using requests.Client.
 func NewFileManager(client *requests.Client) (FileManager, error) {
 	fileManager := defaultFileManager{}
@@ -67,7 +77,7 @@ func (rm defaultFileManager) ListFiles(inbox bool) (*[]File, error) {
     		// Check if the response body contains the specific error message indicating
     		// that the folder is empty or doesn't exist yet.
     		if strings.Contains(string(body), `"tsdFiles" is null`) {
-    			return nil, errors.New("The user folder is empty or does not exist yet")
+    			return nil, &FolderNotFoundError{}
     		}
     		// If it's not an empty folder, it's a genuine authentication error.
     		return nil, errors.New("Authentication error")

--- a/main.go
+++ b/main.go
@@ -96,6 +96,11 @@ func main() {
 		if inboxOptions.List {
 			fileList, err := fileManager.ListFiles(true)
 			if err != nil {
+                    if _, ok := err.(*files.FolderNotFoundError); ok {
+                        log.Fatal(aurora.Red("Inbox Error: The user folder is empty or does not exist yet"))
+                    }
+                }
+			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}
 			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
@@ -130,6 +135,11 @@ func main() {
 		}
 		if inboxOptions.List {
 			fileList, err := fileManager.ListFiles(false)
+			if err != nil {
+                    if _, ok := err.(*files.FolderNotFoundError); ok {
+                        log.Fatal(aurora.Red("Outbox Error: No data has been staged in the outbox yet"))
+                    }
+                }
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -146,19 +146,26 @@ func (s defaultStreamer) uploadFolder(folder *os.File, resume, straight bool) er
 
 func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *string, offset, startChunk int64) error {
 	fileName := filepath.Base(file.Name())
+
+	// List user's files already in inbox to avoid accidental overwrites
 	filesList, err := s.fileManager.ListFiles(true)
 	if err != nil {
 	       	fmt.Println("Could not read previous uploaded files, this is ok if it's your first upload")  
 //		return err
-	}
-	for _, uploadedFile := range *filesList {
-		if fileName == filepath.Base(uploadedFile.FileName) {
-			return errors.New("File " + file.Name() + " is already uploaded. Please, remove it from the Inbox first: lega-commander files -d " + filepath.Base(uploadedFile.FileName))
+	} else {
+		for _, uploadedFile := range *filesList {
+			if fileName == filepath.Base(uploadedFile.FileName) {
+				return errors.New("File " + file.Name() + " is already uploaded. Please, remove it from the Inbox first: lega-commander files -d " + filepath.Base(uploadedFile.FileName))
+			}
 		}
 	}
+
+	// Make sure the file to be uploaded is a crypt4gh encrypted file
 	if err = isCrypt4GHFile(file); err != nil {
 		return err
 	}
+
+
 	totalSize := stat.Size()
 	fmt.Println(aurora.Blue("Uploading file: " + file.Name() + " (" + strconv.FormatInt(totalSize, 10) + " bytes)"))
 	bar := pb.StartNew(100)

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -148,7 +148,8 @@ func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *s
 	fileName := filepath.Base(file.Name())
 	filesList, err := s.fileManager.ListFiles(true)
 	if err != nil {
-		return err
+	       	fmt.Println("Could not read previous uploaded files, this is ok if it's your first upload")  
+//		return err
 	}
 	for _, uploadedFile := range *filesList {
 		if fileName == filepath.Base(uploadedFile.FileName) {
@@ -223,7 +224,7 @@ func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *s
 		return err
 	}
 	checksum := hex.EncodeToString(hashFunction.Sum(nil))
-	fmt.Println("assembling different parts of file together in order to make it! Duration varies based on filesize.")
+	fmt.Println("Assembling the uploaded parts of the file together in order to build it! Duration varies based on filesize.")
 	response, err := s.client.DoRequest(http.MethodPatch,
 		configuration.GetLocalEGAInstanceURL()+"/stream/"+url.QueryEscape(fileName),
 		nil,


### PR DESCRIPTION
I've altered the upload function to allow for a listFiles return value with error passed on from the TSD-File-API. This will happen for first time upload users, that does not have an exisiting inbox yet (will be automatically created at first upload).

The intention behind the listFiles operation before the upload is to check (for non-first-time users) that the filename about to be uploaded does not exist in the inbox from before, and risk being overwritten. The current code should work for an empty file list (first time users w/o inbox as well as users with existing inbox that is empty), as well as list containing filenames (inbox with files in it). 