### PR TITLE
Chore update go to 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
 
-            - name: Set up Go 1.21
+            - name: Set up Go 1.22
               uses: actions/setup-go@v4
               with:
-                  go-version: 1.21
+                  go-version: 1.22
               id: go
 
             - name: Check out code into the Go module directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v1
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elixir-oslo/lega-commander
 
-go 1.21
+go 1.22
 
 require (
 	github.com/buger/jsonparser v1.1.1


### PR DESCRIPTION
- Modified the Go version in `go.mod` to be `1.22`.
- Ran `go mod tidy` to clean up the module dependencies but nothing changed
- Ran go tests, upload and list. 
